### PR TITLE
Fixed slider button bug

### DIFF
--- a/src/components/molecules/Navbar/Navbar.module.scss
+++ b/src/components/molecules/Navbar/Navbar.module.scss
@@ -39,7 +39,7 @@
     inset: 9rem 0 0 0;
     overflow: scroll;
     position: fixed;
-    z-index: 1;
+    z-index: 3;
 
     @include media-query('md') {
       align-items: baseline;


### PR DESCRIPTION
Slider button used to go on top of navigation bar on mobile screens